### PR TITLE
updated validation to check for _ at the end of usernames

### DIFF
--- a/src/error-handling.ts
+++ b/src/error-handling.ts
@@ -129,9 +129,12 @@ export function validateUsername(username: string): void {
     );
   }
 
-  if (!/^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?$/.test(username)) {
+  const standardGithubRegex = /^[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?$/;
+  const idpGithubRegex = /^[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?_[a-zA-Z0-9]+$/;
+
+  if (!standardGithubRegex.test(username) && !idpGithubRegex.test(username)) {
     throw new ValidationError(
-      "Username contains invalid characters",
+      "Username contains invalid characters or does not follow allowed patterns (standard or IdP with _shortname)",
       "username",
     );
   }

--- a/src/github-service.test.ts
+++ b/src/github-service.test.ts
@@ -203,4 +203,48 @@ describe("GitHubService", () => {
       ).rejects.toThrow(ValidationError);
     });
   });
+  
+  test("should accept valid username with dash", async () => {
+    const mockResponse = {data : {assignee: { login : "test-user" } } };
+    mockOctokit.rest.copilot.getCopilotSeatDetailsForUser.mockResolvedValue(
+      mockResponse,
+    );
+    await expect(
+      service.getCopilotSeatDetails("test-org","test-user")
+    ).resolves.toBe(mockResponse);
+  });
+
+  test("should not accept valid username with underscore before the end", async () => {
+    const mockResponse = {data : {assignee: { login : "test_my-user" } } };
+    mockOctokit.rest.copilot.getCopilotSeatDetailsForUser.mockResolvedValue(
+      mockResponse,
+    );
+    await expect(
+      service.getCopilotSeatDetails("test-org","test_my-user")
+    ).rejects.toThrow(ValidationError);
+  
+  });
+
+  test("should accept valid username with underscore before the end", async () => {
+    const mockResponse = {data : {assignee: { login : "test-my_idp" } } };
+    mockOctokit.rest.copilot.getCopilotSeatDetailsForUser.mockResolvedValue(
+      mockResponse,
+    );
+    await expect(
+      service.getCopilotSeatDetails("test-org","test-my_idp")
+    ).resolves.toBe(mockResponse);
+  });
+
+  test("should accept valid username with underscore before the end", async () => {
+    const mockResponse = {data : {assignee: { login : "username_idp" } } };
+    mockOctokit.rest.copilot.getCopilotSeatDetailsForUser.mockResolvedValue(
+      mockResponse,
+    );
+    await expect(
+      service.getCopilotSeatDetails("test-org","username_idp")
+    ).resolves.toBe(mockResponse);
+  });
+
 });
+
+


### PR DESCRIPTION
When looking at the logic for validating usernames any username that is created via an idp will have an _shortname appended to the end thus causing the regex query to fail.