### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   benchmark:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/abirismyname/github-copilot-metrics-mcp-server/security/code-scanning/6](https://github.com/abirismyname/github-copilot-metrics-mcp-server/security/code-scanning/6)

To fix the issue, add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. In this case:
- The workflow needs `contents: read` to check out the code.
- It needs `issues: write` to comment on pull requests.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or specifically to the `benchmark` job. Adding it at the root level is more concise and ensures consistency across jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
