### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI/CD
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main, develop]


### PR DESCRIPTION
Potential fix for [https://github.com/abirismyname/github-copilot-metrics-mcp-server/security/code-scanning/5](https://github.com/abirismyname/github-copilot-metrics-mcp-server/security/code-scanning/5)

To fix the issue, we will add a `permissions` block to the root of the workflow. This block will define the least privileges required for the workflow to function. Based on the steps in the workflow, the `contents: read` permission is sufficient, as there are no actions that require write access (e.g., creating issues or modifying pull requests). This change will apply to all jobs in the workflow unless overridden by a job-specific `permissions` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
