### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/feature.yaml
+++ b/.github/workflows/feature.yaml
@@ -1,4 +1,6 @@
 name: Run Tests
+permissions:
+  contents: read
 on:
   pull_request:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/abirismyname/github-copilot-metrics-mcp-server/security/code-scanning/4](https://github.com/abirismyname/github-copilot-metrics-mcp-server/security/code-scanning/4)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow only requires read access to the repository contents, we can set `contents: read` at the root level of the workflow. This ensures that all jobs in the workflow inherit the least privilege required to complete their tasks.

**Steps to implement the fix:**
1. Add a `permissions` block at the root level of the workflow file.
2. Set `contents: read` to limit the `GITHUB_TOKEN` permissions to read-only access for repository contents.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
