### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -41,6 +44,8 @@ jobs:
   security:
     runs-on: ubuntu-latest
     needs: test
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Potential fix for [https://github.com/abirismyname/github-copilot-metrics-mcp-server/security/code-scanning/1](https://github.com/abirismyname/github-copilot-metrics-mcp-server/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Since the workflow involves checking out code, installing dependencies, running tests, and performing security audits, the `contents: read` permission is sufficient for most operations. If specific jobs require additional permissions (e.g., `pull-requests: write`), those can be defined at the job level.

The `permissions` block will be added at the root level of the workflow to apply to all jobs. If any job requires different permissions, a job-specific `permissions` block can be added.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
